### PR TITLE
修正使用 cluster 时的 BUG

### DIFF
--- a/lib/dir.js
+++ b/lib/dir.js
@@ -8,7 +8,11 @@ var dir = function(){
 	var fileArray = fs.readdirSync(path);//获取所有文件名
 
 	fileArray.forEach(function(v,i){ //清空文件夹
-		fs.unlinkSync(p.join(path,v));
+		try {
+			fs.unlinkSync(p.join(path,v));
+		} catch(e) {
+			// console.log(e);
+		}
 	})
 
 }


### PR DESCRIPTION
如果使用 cluster 多进程启动，每个进程都会读取到相似的目录，其中的文件可能已经被其他进程先删除，此时其他进程再删报错会阻塞进程。
