### PR TITLE
Add is_first set to true after timer cache

### DIFF
--- a/lib/hcap.js
+++ b/lib/hcap.js
@@ -136,7 +136,7 @@ CAP.prototype._custom_create = function(){//自定义创建
 CAP.prototype._timer = function(){//存入计数器的函数	
 	
 	this._get_count++;//记录timer调用次数
-
+	this.is_first = true;
 	this._create();
 }
 


### PR DESCRIPTION
1、在timer定时缓存时，加入对is_first重置为true，防止在_call_create()中进行同步读（readFile）导致的IO
Exception问题，自己电脑亲测通过，Apache Bench测试100并发不再有问题