### PR TITLE
fix: cause node exit when unlink failed.

### DIFF
--- a/lib/dir.js
+++ b/lib/dir.js
@@ -43,11 +43,11 @@ obj.dir = function(isTiming){
 					if(isTiming){
 						var nameList = v.split('_')
 						if(nameList[2] == pid && (now - nameList[3]>=60*1000*2)){
-							fs.unlink(p.join(path,v));
+							fs.unlink(p.join(path,v), function(e){ console.error(e); });
 						}
 					}
 					else{
-						fs.unlink(p.join(path,v));
+						fs.unlink(p.join(path,v), function(e){ console.error(e); });
 					}		
 				} catch(e) {
 					console.log(e);


### PR DESCRIPTION
When server is shutdown and restart immediately, ccap will unlink old images.
But the files may be not exist because the old process has unlinked them.
This will cause unlink throw ENOENT, and unlink callback is not supplied.
So uncaughtException is emitted and node process exit.

Solution:
Provide callback for fs.unlink will fix it.