### PR TITLE
fix: convert indentation to spaces to fix syntax error when compile on linux

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -9,8 +9,8 @@
                                "libraries": [],
                                "cflags_cc": ["-fexceptions","-Dcimg_display=0"],
                                'xcode_settings': {
-						            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
-						          }
+                        'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
+                      }
             }],
             ["OS==\"linux\"", {
                                "sources": ["addon/jpeglib/jaricom.c", "addon/jpeglib/jcapimin.c", "addon/jpeglib/jcapistd.c", 


### PR DESCRIPTION
when I use npm install ccap on linux, it throw syntax error. But, if I convert indentation to spaces in binding.gyp and then rebuild it use node-gyp and install it by hand, it's okay.


here is the syntax error stdout:

$ npm install -g ccap
/
> ccap@0.6.4 preinstall /home/h5/local/node/lib/node_modules/ccap
> node make.js

I'm glad you to select ccap, enjoy it!

ccap is a cross plat form and portable nodejs simple captcha module, simple api and lightweight.

starting compile ccap! good luck!
\
> ccap@0.6.4 install /home/h5/local/node/lib/node_modules/ccap
> node-gyp rebuild

Traceback (most recent call last):
  File "/home/h5/local/node/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py",
line 18, in <module>
    sys.exit(gyp.script_main())
  File "/home/h5/local/node/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 533, in script_main
    return main(sys.argv[1:])
  File "/home/h5/local/node/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 526, in main
    return gyp_main(args)
  File "/home/h5/local/node/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 502, in gyp_main
    params, options.check, options.circular_check)
  File "/home/h5/local/node/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 129, in Load
    params['parallel'], params['root_targets'])
  File "/home/h5/local/node/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py",
line 2736, in Load
    variables, includes, depth, check, True)
  File "/home/h5/local/node/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py",
line 386, in LoadTargetBuildFile
    includes, True, check)
  File "/home/h5/local/node/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py",
line 238, in LoadOneBuildFile
    None)
  File "binding.gyp", line 1
    {
     ^
SyntaxError: invalid syntax
gyp ERR! configure error
gyp ERR! stack Error: `gyp` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onCpExit (/home/h5/local/node/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:355:16)
gyp ERR! stack     at emitTwo (events.js:87:13)
gyp ERR! stack     at ChildProcess.emit (events.js:172:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)
gyp ERR! System Linux 2.6.32-431.23.3.el6.x86_64
gyp ERR! command "/home/h5/local/node/bin/node" "/home/h5/local/node/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /home/h5/local/node/lib/node_modules/ccap
gyp ERR! node -v v4.1.1
gyp ERR! node-gyp -v v3.0.3
gyp ERR! not ok                     

------------------------------------------------