### PR TITLE
fix cap_img dir not exsit bug

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
 build
-cap_img
 node_modules
 .git


### PR DESCRIPTION
@DoubleSpout 
The cap_img does not be packaged in the pr [https://github.com/DoubleSpout/ccap/pull/61](pr).
Sorry for the bug!!!