### PR TITLE
修复pm2运行报错的问题

### DIFF
--- a/lib/dir.js
+++ b/lib/dir.js
@@ -7,7 +7,7 @@ var cluster = require('cluster');
 
 
 var rootPath = p.join(__dirname, '..', 'cap_img');
-var pathCluster =  cluster.isWorker ? cluster.worker.id : '0';
+var pathCluster =  cluster.isWorker ? String(cluster.worker.id) : '0';
 var path = p.join(rootPath, pathCluster);
 
 var pid = process.pid;

--- a/lib/hcap.js
+++ b/lib/hcap.js
@@ -31,7 +31,7 @@ var ins_count = 0;//记录实例化次数
 var cluster = require('cluster');
 
 var rootPath = path.join(__dirname, '..', 'cap_img');
-var pathCluster =  cluster.isWorker ? cluster.worker.id : '0';
+var pathCluster =  cluster.isWorker ? String(cluster.worker.id) : '0';
 
 var img_path = path.join(rootPath, pathCluster);
 var pid = process.pid;


### PR DESCRIPTION
pm2运行错误信息

```
[2016-07-06 15:57:32] [Error] TypeError: Path must be a string. Received 1438
midway-mop-64     at assertPath (path.js:8:11)
midway-mop-64     at Object.posix.join (path.js:479:5)
midway-mop-64     at Object.<anonymous> (/home/laso/midWay/node_modules/midway-mop/node_modules/ccap/lib/hcap.js:36:21)
midway-mop-64     at Module._compile (module.js:409:26)
midway-mop-64     at Object.Module._extensions..js (module.js:416:10)
midway-mop-64     at Module.load (module.js:343:32)
midway-mop-64     at Function.Module._load (module.js:300:12)
midway-mop-64     at Function._load (/usr/local/lib/node_modules/pm2/node_modules/pmx/lib/transaction.js:62:21)
midway-mop-64     at Module.require (module.js:353:17)
midway-mop-64     at require (internal/module.js:12:17)
midway-mop-64     at Object.<anonymous> (/home/laso/midWay/node_modules/midway-mop/node_modules/ccap/index.js:1:80)
midway-mop-64     at Module._compile (module.js:409:26)
midway-mop-64     at Object.Module._extensions..js (module.js:416:10)
midway-mop-64     at Module.load (module.js:343:32)
midway-mop-64     at Function.Module._load (module.js:300:12)
midway-mop-64     at Function._load (/usr/local/lib/node_modules/pm2/node_modules/pmx/lib/transaction.js:62:21)
```
