### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,11 +13,11 @@ linux support jpeg,windows and mac only support bmp!
 
 *Please never using ccap in production on windows and mac, only with linux.*
 
-##performance
+## performance
 
   generate captcha picture 1204/sec;//BMP unzip
 
-##Install
+## Install
 
    npm install ccap 	  (new version, need node 0.12.x and 4.x.x and 6.x.x, on linux need gcc v4.8+)
 
@@ -35,7 +35,7 @@ linux support jpeg,windows and mac only support bmp!
    
    2.cnpm install ccap
 
-##Instantiated
+## Instantiated
 
    these three ways all will be ok:
 
@@ -66,7 +66,7 @@ linux support jpeg,windows and mac only support bmp!
 	});
 	   
 
-##API
+## API
    
 	var captcha = ccap();
 
@@ -77,7 +77,7 @@ linux support jpeg,windows and mac only support bmp!
 	var buffer = ary[1];
 
 
-##Simple Example
+## Simple Example
 	
 	var http = require('http');
 	
@@ -101,7 +101,7 @@ linux support jpeg,windows and mac only support bmp!
 
 	console.log('Server running at http://127.0.0.1:8124/');
 
-#Stop and start timer cache
+# Stop and start timer cache
 
 	var ccap = require('ccap')();
 

--- a/release/node-v0.12.x-linux-x64/node_modules/ccap/readme.md
+++ b/release/node-v0.12.x-linux-x64/node_modules/ccap/readme.md
@@ -13,11 +13,11 @@ linux support jpeg,windows and mac only support bmp!
 
 *Please never using ccap in production on windows and mac, only with linux.*
 
-##performance
+## performance
 
   generate captcha picture 1204/sec;//BMP unzip
 
-##Install
+## Install
 
    npm install ccap 	  (new version, need node 0.12.x and 4.x.x)
 
@@ -25,7 +25,7 @@ linux support jpeg,windows and mac only support bmp!
 
    var ccap = require('ccap')
 
-##Instantiated
+## Instantiated
 
    these three ways all will be ok:
 
@@ -56,7 +56,7 @@ linux support jpeg,windows and mac only support bmp!
 	});
 	   
 
-##API
+## API
    
 	var captcha = ccap();
 
@@ -67,7 +67,7 @@ linux support jpeg,windows and mac only support bmp!
 	var buffer = ary[1];
 
 
-##Simple Example
+## Simple Example
 	
 	var http = require('http');
 	
@@ -91,7 +91,7 @@ linux support jpeg,windows and mac only support bmp!
 
 	console.log('Server running at http://127.0.0.1:8124/');
 
-#Stop and start timer cache
+# Stop and start timer cache
 
 	var ccap = require('ccap')();
 

--- a/release/node-v4.1.x-linux-x64/node_modules/ccap/readme.md
+++ b/release/node-v4.1.x-linux-x64/node_modules/ccap/readme.md
@@ -13,11 +13,11 @@ linux support jpeg,windows and mac only support bmp!
 
 *Please never using ccap in production on windows and mac, only with linux.*
 
-##performance
+## performance
 
   generate captcha picture 1204/sec;//BMP unzip
 
-##Install
+## Install
 
    npm install ccap 	  (new version, need node 0.12.x and 4.x.x)
 
@@ -25,7 +25,7 @@ linux support jpeg,windows and mac only support bmp!
 
    var ccap = require('ccap')
 
-##Instantiated
+## Instantiated
 
    these three ways all will be ok:
 
@@ -56,7 +56,7 @@ linux support jpeg,windows and mac only support bmp!
 	});
 	   
 
-##API
+## API
    
 	var captcha = ccap();
 
@@ -67,7 +67,7 @@ linux support jpeg,windows and mac only support bmp!
 	var buffer = ary[1];
 
 
-##Simple Example
+## Simple Example
 	
 	var http = require('http');
 	
@@ -91,7 +91,7 @@ linux support jpeg,windows and mac only support bmp!
 
 	console.log('Server running at http://127.0.0.1:8124/');
 
-#Stop and start timer cache
+# Stop and start timer cache
 
 	var ccap = require('ccap')();
 

--- a/release/node-v4.2.x-windows-x64/node_modules/ccap/readme.md
+++ b/release/node-v4.2.x-windows-x64/node_modules/ccap/readme.md
@@ -13,11 +13,11 @@ linux support jpeg,windows and mac only support bmp!
 
 *Please never using ccap in production on windows and mac, only with linux.*
 
-##performance
+## performance
 
   generate captcha picture 1204/sec;//BMP unzip
 
-##Install
+## Install
 
    npm install ccap 	  (new version, need node 0.12.x and 4.x.x, on linux need gcc v4.8+)
 
@@ -27,7 +27,7 @@ linux support jpeg,windows and mac only support bmp!
 
    if you don't want to update gcc version, ccap package Compiled file is in folder `release`, just download it and copy it to your `node_modules`. 
 
-##Instantiated
+## Instantiated
 
    these three ways all will be ok:
 
@@ -58,7 +58,7 @@ linux support jpeg,windows and mac only support bmp!
 	});
 	   
 
-##API
+## API
    
 	var captcha = ccap();
 
@@ -69,7 +69,7 @@ linux support jpeg,windows and mac only support bmp!
 	var buffer = ary[1];
 
 
-##Simple Example
+## Simple Example
 	
 	var http = require('http');
 	
@@ -93,7 +93,7 @@ linux support jpeg,windows and mac only support bmp!
 
 	console.log('Server running at http://127.0.0.1:8124/');
 
-#Stop and start timer cache
+# Stop and start timer cache
 
 	var ccap = require('ccap')();
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
