### PR TITLE
docs: fix simple typo, spliting -> splitting

### DIFF
--- a/addon/jpeglib/CImg.h
+++ b/addon/jpeglib/CImg.h
@@ -43329,7 +43329,7 @@ namespace cimg_library_suffixed {
     //! Return a list where each image has been split along the specified axis.
     /**
         \param axis Axis to split images along.
-        \param nb Number of spliting parts for each image.
+        \param nb Number of splitting parts for each image.
     **/
     CImgList<T>& split(const char axis, const int nb=0) {
       return get_split(axis,nb).move_to(*this);

--- a/release/node-v0.12.x-linux-x64/node_modules/ccap/addon/jpeglib/CImg.h
+++ b/release/node-v0.12.x-linux-x64/node_modules/ccap/addon/jpeglib/CImg.h
@@ -43329,7 +43329,7 @@ namespace cimg_library_suffixed {
     //! Return a list where each image has been split along the specified axis.
     /**
         \param axis Axis to split images along.
-        \param nb Number of spliting parts for each image.
+        \param nb Number of splitting parts for each image.
     **/
     CImgList<T>& split(const char axis, const int nb=0) {
       return get_split(axis,nb).move_to(*this);

--- a/release/node-v4.1.x-linux-x64/node_modules/ccap/addon/jpeglib/CImg.h
+++ b/release/node-v4.1.x-linux-x64/node_modules/ccap/addon/jpeglib/CImg.h
@@ -43329,7 +43329,7 @@ namespace cimg_library_suffixed {
     //! Return a list where each image has been split along the specified axis.
     /**
         \param axis Axis to split images along.
-        \param nb Number of spliting parts for each image.
+        \param nb Number of splitting parts for each image.
     **/
     CImgList<T>& split(const char axis, const int nb=0) {
       return get_split(axis,nb).move_to(*this);

--- a/release/node-v4.2.x-windows-x64/node_modules/ccap/addon/jpeglib/CImg.h
+++ b/release/node-v4.2.x-windows-x64/node_modules/ccap/addon/jpeglib/CImg.h
@@ -43329,7 +43329,7 @@ namespace cimg_library_suffixed {
     //! Return a list where each image has been split along the specified axis.
     /**
         \param axis Axis to split images along.
-        \param nb Number of spliting parts for each image.
+        \param nb Number of splitting parts for each image.
     **/
     CImgList<T>& split(const char axis, const int nb=0) {
       return get_split(axis,nb).move_to(*this);


### PR DESCRIPTION
There is a small typo in addon/jpeglib/CImg.h, release/node-v0.12.x-linux-x64/node_modules/ccap/addon/jpeglib/CImg.h, release/node-v4.1.x-linux-x64/node_modules/ccap/addon/jpeglib/CImg.h, release/node-v4.2.x-windows-x64/node_modules/ccap/addon/jpeglib/CImg.h.

Should read `splitting` rather than `spliting`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md